### PR TITLE
first stab at crunchtope continuous integration

### DIFF
--- a/.github/workflows/crunchtope-ci.yml
+++ b/.github/workflows/crunchtope-ci.yml
@@ -1,0 +1,47 @@
+name: CrunchTope CI
+
+on: [workflow_dispatch, push, pull_request]
+
+env:
+  # Customizing build type
+  BUILD_TYPE: DEBUG
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: package-install
+      run: |
+        sudo apt-get -qq update
+        sudo apt -qq install gfortran libopenmpi-dev libhdf5-openmpi-dev hdf5-helpers
+
+    - name: directories-variables
+      run: |
+        echo "PETSC_DIR=$HOME/petsc" >> $GITHUB_ENV
+        echo "PETSC_ARCH=debug" >> $GITHUB_ENV
+
+    - name: petsc-install
+      run: |
+        git clone https://gitlab.com/petsc/petsc.git --branch v3.19.4 $PETSC_DIR
+        cd $PETSC_DIR
+        echo "CrunchTope >> Configuring petsc"
+        PETSC_ARCH=$PETSC_ARCH ./configure --with-mpi=1 --with-debugging=1 --with-shared-libraries=1 --download-fblaslapack=1 --with-hdf5-dir=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+        echo "CrunchTope >> Building petsc"
+        make
+
+    - uses: actions/checkout@v2
+    
+    - name: crunchtope-build
+      run: |
+        cd Source
+        echo "Building CrunchTope"
+        make
+        
+    - name: crunchtope-run
+      run: |
+        cd Exercises/Ex1Speciation
+        echo "Running Ex1Speciation"
+        ../../Source/CrunchTope ShortCourse1.in
+

--- a/Containers/Containerfile-arm64
+++ b/Containers/Containerfile-arm64
@@ -1,0 +1,33 @@
+FROM docker.io/arm64v8/gcc:12.3
+
+RUN apt-get -qq update
+RUN apt-get -qq install liblapack-dev
+
+# add crunch_user
+RUN useradd -ms /bin/bash crunch_user
+
+# Switch to crunch_user
+USER crunch_user
+
+# Change the Working Directory
+WORKDIR /home/crunch_user
+
+# PETSc install
+RUN git clone https://gitlab.com/petsc/petsc.git petsc
+WORKDIR /home/crunch_user/petsc
+RUN git checkout v3.20.4
+ARG PETSC_DIR=/home/crunch_user/petsc
+ARG PETSC_ARCH=gcc-opt
+RUN ./configure --with-cc=gcc --with-cxx=g++ --with-fc=gfortran --with-debugging=0 --with-shared-libraries=0 --with-x=0 LIBS=-lstdc++ --with-c2html=0 --with-cxx-dialect=C++11 --with-mpi=0
+RUN make $PETSC_DIR $PETSC_ARCH all
+RUN make $PETSC_DIR $PETSC_ARCH check
+
+WORKDIR /home/crunch_user
+
+# CrunchTope install
+RUN git clone https://github.com/CISteefel/CrunchTope.git crunchtope
+WORKDIR /home/crunch_user/crunchtope/Source
+RUN make
+
+WORKDIR /home/crunch_user
+

--- a/Containers/Containerfile-intel
+++ b/Containers/Containerfile-intel
@@ -1,0 +1,29 @@
+FROM docker.io/intel/hpckit
+
+# add crunch_user
+RUN useradd -ms /bin/bash crunch_user
+
+# Switch to crunch_user
+USER crunch_user
+
+# Change the Working Directory
+WORKDIR /home/crunch_user
+
+# PETSc install
+RUN git clone https://gitlab.com/petsc/petsc.git petsc
+WORKDIR /home/crunch_user/petsc
+RUN git checkout v3.20.4
+ARG PETSC_DIR=/home/crunch_user/petsc
+ARG PETSC_ARCH=intel-opt
+RUN ./configure --with-cc=icx --with-cxx=icpx --with-fc=ifx --with-debugging=0 --with-shared-libraries=0 --with-blas-lapack-dir=/opt/intel/oneapi/mkl/2024.0/lib --with-x=0 LIBS=-lstdc++ --with-c2html=0 --with-cxx-dialect=C++11 --with-mpi=0
+RUN make $PETSC_DIR $PETSC_ARCH all
+RUN make $PETSC_DIR $PETSC_ARCH check
+
+WORKDIR /home/crunch_user
+
+# CrunchTope install
+RUN git clone https://github.com/CISteefel/CrunchTope.git crunchtope
+WORKDIR /home/crunch_user/crunchtope/Source
+RUN make
+
+WORKDIR /home/crunch_user


### PR DESCRIPTION
This adds a very basic continuous integration to the repository using github Actions (see yaml file: .github/workflows/crunchtope-ci.yml). 
First, it builds petsc 3.9.4 (debug), then uses petsc to build CrunchTope, and finally runs Ex1Speciations.
Currently (1) it is set up for an ubuntu-latest runner, (2)  the petsc build can be simplified to be faster and save some time if needed (but left as is in case something similar needs to be done for crunchclay, which e.g. requires mpi), (3) no results are checked for the Ex1Speciation run, which is simply a placeholder for setting up more sophisticated test runs.   
Developers must update the Makefile under Source accordingly if files are added/removed to/from the project. 
Developers must update the petsc version in .github/workflows/crunchtope-ci.yml when they do so locally as well. 


