### PR TITLE
fixed restart

### DIFF
--- a/Source/CrunchTope.F90
+++ b/Source/CrunchTope.F90
@@ -3597,7 +3597,7 @@ END DO
     WRITE(iures) spsurfold
     WRITE(iures) raq_tot
     WRITE(iures) sion
-    WRITE(iures) jinit
+    !WRITE(iures) jinit
 
 !!    WRITE(iures) mumin_decay
     WRITE(iures) keqmin


### PR DESCRIPTION
Previously, Crunch was not able to read restart files. I fixed it. I tested this with exercise 6-CesiumIonExchange.