### PR TITLE
Fix: save and restore lngammawater in restart files. lngammawater (lo…

### DIFF
--- a/Source/CrunchTope.F90
+++ b/Source/CrunchTope.F90
@@ -3129,6 +3129,7 @@ END IF
     WRITE(iures) spsurfold
     WRITE(iures) raq_tot
     WRITE(iures) sion
+    WRITE(iures) lngammawater
     WRITE(iures) jinit   !! Read IntegerDummyArray(nxyz)
     WRITE(iures) keqmin
     WRITE(iures) volfx
@@ -3393,6 +3394,7 @@ END IF
     WRITE(iures) spsurfold
     WRITE(iures) raq_tot
     WRITE(iures) sion
+    WRITE(iures) lngammawater
     WRITE(iures) jinit
 
 !!    WRITE(iures) mumin_decay

--- a/Source/restart.F90
+++ b/Source/restart.F90
@@ -176,7 +176,8 @@ END IF
     READ(iures) spsurfold 
     READ(iures) raq_tot
     READ(iures) sion
-    
+    READ(iures) lngammawater
+
     IF (ALLOCATED(IntegerDummyArray)) THEN
       DEALLOCATE(IntegerDummyArray)
     END IF


### PR DESCRIPTION
…g water activity) was not being written to restart files or read back on restart. Fix adds WRITE(iures) lngammawater after sion in both write blocks in CrunchTope.F90, and READ(iures) lngammawater after sion in restart.F90.